### PR TITLE
Enable Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+# Copyright 2020 Adam Chalkley
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+version: 2
+updates:
+
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   open-pull-requests-limit: 10
+  #   target-branch: "master"
+  #   schedule:
+  #     interval: "daily"
+  #     time: "02:00"
+  #     timezone: "America/Chicago"
+  #   assignees:
+  #     - "atc0005"
+  #   labels:
+  #     - "dependencies"
+  #     - "packages"
+  #   allow:
+  #     - dependency-type: "all"
+  #   commit-message:
+  #     prefix: "pip"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "CI"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "ghaw"


### PR DESCRIPTION
- Stub/comment out pip updates
  - not needed yet as this project is only currently using
    the standard library

- Enable GitHub Actions updates
  - not used *yet*, but will submit a GHAW for Markdown
    linting as a follow-up PR

fixes GH-12