### PR TITLE
Explicitly set stdout and stderr output encoding

### DIFF
--- a/doc/references.md
+++ b/doc/references.md
@@ -22,3 +22,5 @@
 - <http://stackoverflow.com/questions/3845423/remove-empty-strings-from-a-list-of-strings#comment56770861_3845449>
 - <https://stackoverflow.com/questions/415511/how-to-get-the-current-time-in-python>
 - <https://stackoverflow.com/questions/7331351/python-email-header-decoding-utf-8>
+
+- <https://stackoverflow.com/questions/56995919/change-python-3-7-default-encoding-from-cp1252-to-cp65001-aka-utf-8>

--- a/list_emails.py
+++ b/list_emails.py
@@ -19,6 +19,7 @@ import datetime
 import email.parser
 import email.policy
 import imaplib
+import io
 import json
 import logging
 import logging.handlers
@@ -26,6 +27,9 @@ import os
 import pprint
 import sys
 
+# Set encoding for stdout, stderr explicitly to UTF-8
+sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding = 'utf-8')
+sys.stderr = io.TextIOWrapper(sys.stderr.detach(), encoding = 'utf-8')
 
 #######################################################
 # CONSTANTS - Modify INI config files instead


### PR DESCRIPTION
Attempt to prevent charmap encoding issues with down-conversion to default CP-1252 encoding.

refs GH-20