### PR TITLE
Attempt to close mailbox after successful select

### DIFF
--- a/doc/references.md
+++ b/doc/references.md
@@ -17,6 +17,7 @@
 - <https://pymotw.com/3/configparser/>
 
 - <http://stackoverflow.com/questions/7314942/python-imaplib-to-get-gmail-inbox-subjects-titles-and-sender-name>
+- <https://stackoverflow.com/questions/39115141/imaplib-error-command-search-illegal-in-state-auth-only-allowed-in-states-sele>
 - <http://stackoverflow.com/questions/22392120/python-imap-mail-seach-with-minutes>
 - <http://stackoverflow.com/questions/12556649/increasing-speed-of-imap-bulk-message-deletion-in-python>
 - <http://stackoverflow.com/questions/3845423/remove-empty-strings-from-a-list-of-strings#comment56770861_3845449>


### PR DESCRIPTION
- Move `mailbox.close()` step after successful select

- Remove try/except block since `mailbox.select()` does not
  produce an exception

- Tweak doc comments to better emphasize importance of
  checking result

- Emit "logout success" message for each account as INFO
  log level to better indicate to user script progress

fixes GH-25